### PR TITLE
Fix typo in SphereTestKernel ToString() method

### DIFF
--- a/PlowTracer Core/Core/Kernels/SphereTestKernel.cs
+++ b/PlowTracer Core/Core/Kernels/SphereTestKernel.cs
@@ -86,6 +86,6 @@ public class SphereTestKernel : IRenderKernel
 
     public override string ToString()
     {
-        return "Sphere Text";
+        return "Sphere Test";
     }
 }


### PR DESCRIPTION
- Corrected the return string from "Sphere Text" to "Sphere Test".
- This change ensures that the method accurately reflects the class name, improving code readability and consistency.