### PR TITLE
Implemented Chapter 7 of Ray Tracing In One Weekend

### DIFF
--- a/.idea/.idea.PlowTracer/.idea/avalonia.xml
+++ b/.idea/.idea.PlowTracer/.idea/avalonia.xml
@@ -11,6 +11,7 @@
         <entry key="PlowTracer GUI/Views/Controls/Layout/LayoutGroup.axaml" value="PlowTracer GUI/PlowTracer GUI.csproj" />
         <entry key="PlowTracer GUI/Views/Controls/Layout/LayoutItem.axaml" value="PlowTracer GUI/PlowTracer GUI.csproj" />
         <entry key="PlowTracer GUI/Views/MainWindow.axaml" value="PlowTracer GUI/PlowTracer GUI.csproj" />
+        <entry key="PlowTracer GUI/Views/MainWindowView.axaml" value="PlowTracer GUI/PlowTracer GUI.csproj" />
         <entry key="PlowTracer GUI/Views/RenderPanelView.axaml" value="PlowTracer GUI/PlowTracer GUI.csproj" />
         <entry key="PlowTracer GUI/Views/RenderSettingsView.axaml" value="PlowTracer GUI/PlowTracer GUI.csproj" />
         <entry key="PlowTracer GUI/Views/RenderView.axaml" value="PlowTracer GUI/PlowTracer GUI.csproj" />

--- a/PlowTracer Core Tests/Core/Kernels/ColorOutputTestKernelTests.cs
+++ b/PlowTracer Core Tests/Core/Kernels/ColorOutputTestKernelTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -21,7 +22,7 @@ public class ColorOutputTestKernelTests
     [InlineData(256, 256)]
     public void TEST_CreateRenderSettings(int p_width, int p_height)
     {
-        var renderSettings = new RenderSettings(p_width, p_height);
+        var renderSettings = new RenderSettings(p_width, p_height, Vector3.Zero, 90, 1);
         
         renderSettings.Should().NotBeNull();
         renderSettings.Width.Should().Be(p_width);
@@ -33,7 +34,7 @@ public class ColorOutputTestKernelTests
     {
         var createRenderSettingsAction = () =>
                                          {
-                                             _ = new RenderSettings(1, 1);
+                                             _ = new RenderSettings(1, 1, Vector3.Zero, 90, 1);
                                          };
 
         createRenderSettingsAction.Should().Throw<ArgumentException>();
@@ -50,7 +51,7 @@ public class ColorOutputTestKernelTests
     [InlineData(256, 256)]
     public async Task TEST_Render(int p_width, int p_height)
     {
-        var renderSettings = new RenderSettings(p_width, p_height);
+        var renderSettings = new RenderSettings(p_width, p_height, Vector3.Zero, 90, 1);
 
         var kernel = new ColorOutputTestKernel();
 

--- a/PlowTracer Core/Core/Kernels/CameraTestKernel.cs
+++ b/PlowTracer Core/Core/Kernels/CameraTestKernel.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-using PlowTracer.Core.DataStructures.Render.Primitives;
+using PlowTracer.Core.DataStructures.Render.Primitives.Camera;
 using PlowTracer.Core.DataStructures.Render.Primitives.IntersectableEntities;
 using PlowTracer.Core.DataStructures.Render.Primitives.IntersectableEntities.Shapes;
 using PlowTracer.Core.DataStructures.Render.Result;
@@ -11,29 +10,10 @@ using PlowTracer.Core.DataStructures.Render.Settings;
 
 namespace PlowTracer.Core.Core.Kernels;
 
-public class SurfaceNormalTestKernel : IRenderKernel
+public class CameraTestKernel : IRenderKernel
 {
     public async Task<RenderResult> Render(RenderSettings p_settings)
     {
-        var aspectRatio = (float)p_settings.Width / p_settings.Height;
-
-        const float focalLength = 1.0f;
-
-        const float viewportHeight = 2.0f;
-
-        var viewportWidth = viewportHeight * aspectRatio;
-
-        var cameraCenter = Vector3.Zero;
-
-        var viewportU = new Vector3(viewportWidth, 0, 0);
-        var viewportV = new Vector3(0, -viewportHeight, 0);
-
-        var pixelDeltaU = viewportU / p_settings.Width;
-        var pixelDeltaV = viewportV / p_settings.Height;
-
-        var viewportUpperLeft = cameraCenter      - new Vector3(0, 0, focalLength) - viewportU / 2.0f - viewportV / 2.0f;
-        var upperLeftPixel  = viewportUpperLeft + 0.5f                                       * ( pixelDeltaU + pixelDeltaV );
-
         var scene = new Scene([
                                   new Sphere(new Vector3(0.0f, 0.0f, -1.0f), 0.5f),
                                   new Sphere(new Vector3(0.0f, -100.5f, -1.0f), 100.0f)
@@ -41,7 +21,9 @@ public class SurfaceNormalTestKernel : IRenderKernel
 
         var renderResult = new RenderResult(p_settings.Width, p_settings.Height);
 
-        const byte alpha = 0xFF;
+        var camera = new ThinLensCamera(p_settings, scene);
+        
+        const byte alpha  = 0xFF;
 
         var resultDataIndex = 0; // Image format is a flat array, so start at 0 index and count up for each inserted value. - Comment by Matt Heimlich on 11/14/2024 @ 16:55:27
 
@@ -49,12 +31,8 @@ public class SurfaceNormalTestKernel : IRenderKernel
         {
             for ( var column = 0; column < p_settings.Width; ++column )
             {
-                var pixelCenter  = upperLeftPixel + column * pixelDeltaU + row * pixelDeltaV;
-                var rayDirection = pixelCenter      - cameraCenter;
-
-                var ray = new Ray(cameraCenter, rayDirection);
-
-                var pixelColor = GetPixelColor(ref ray, scene);
+                var ray = camera.GetRay(column, row);
+                var pixelColor = camera.GetPixelColor(ref ray);
 
                 var formattedRed   = (int)MathF.Round(255 * pixelColor.X, MidpointRounding.AwayFromZero);
                 var formattedGreen = (int)MathF.Round(255 * pixelColor.Y, MidpointRounding.AwayFromZero);
@@ -70,23 +48,8 @@ public class SurfaceNormalTestKernel : IRenderKernel
         return await Task.FromResult(renderResult);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Vector3 GetPixelColor(ref Ray p_ray, Scene p_scene)
-    {
-        var intersection = p_scene.GetIntersection(ref p_ray);
-        
-        if ( intersection.Intersected )
-        {
-            return 0.5f * ( intersection.Normal + Vector3.One );
-        }
-
-        var unitDirection = Vector3.Normalize(p_ray.Direction);
-        var a             = 0.5f * ( unitDirection.Y + 1.0f );
-        return ( 1.0f - a ) * Vector3.One + a * new Vector3(0.5f, 0.7f, 1.0f);
-    }
-
     public override string ToString()
     {
-        return "Surface Normal Test";
+        return "Camera Test";
     }
 }

--- a/PlowTracer Core/Core/Kernels/RayTestKernel.cs
+++ b/PlowTracer Core/Core/Kernels/RayTestKernel.cs
@@ -29,7 +29,7 @@ public class RayTestKernel : IRenderKernel
         var pixelDeltaV = viewportV / p_settings.Height;
         
         var viewportUpperLeft = cameraCenter - new Vector3(0, 0, focalLength) - viewportU / 2.0f - viewportV / 2.0f;
-        var pixel100Location = viewportUpperLeft + 0.5f * (pixelDeltaU + pixelDeltaV);
+        var upperLeftPixel = viewportUpperLeft + 0.5f * (pixelDeltaU + pixelDeltaV);
         
         var renderResult = new RenderResult(p_settings.Width, p_settings.Height);
         
@@ -41,7 +41,7 @@ public class RayTestKernel : IRenderKernel
         {
             for (var column = 0; column < p_settings.Width; ++column)
             {
-                var pixelCenter = pixel100Location + column * pixelDeltaU + row * pixelDeltaV;
+                var pixelCenter = upperLeftPixel + column * pixelDeltaU + row * pixelDeltaV;
                 var rayDirection = pixelCenter - cameraCenter;
                 
                 var ray = new Ray(cameraCenter, rayDirection);

--- a/PlowTracer Core/Core/Kernels/SphereTestKernel.cs
+++ b/PlowTracer Core/Core/Kernels/SphereTestKernel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Numerics;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 
 using PlowTracer.Core.DataStructures.Render.Primitives;
@@ -29,7 +30,7 @@ public class SphereTestKernel : IRenderKernel
         var pixelDeltaV = viewportV / p_settings.Height;
         
         var viewportUpperLeft = cameraCenter - new Vector3(0, 0, focalLength) - viewportU / 2.0f - viewportV / 2.0f;
-        var pixel100Location = viewportUpperLeft + 0.5f * (pixelDeltaU + pixelDeltaV);
+        var upperLeftPixel = viewportUpperLeft + 0.5f * (pixelDeltaU + pixelDeltaV);
         
         var renderResult = new RenderResult(p_settings.Width, p_settings.Height);
         
@@ -41,7 +42,7 @@ public class SphereTestKernel : IRenderKernel
         {
             for (var column = 0; column < p_settings.Width; ++column)
             {
-                var pixelCenter = pixel100Location + column * pixelDeltaU + row * pixelDeltaV;
+                var pixelCenter = upperLeftPixel + column * pixelDeltaU + row * pixelDeltaV;
                 var rayDirection = pixelCenter - cameraCenter;
                 
                 var ray = new Ray(cameraCenter, rayDirection);

--- a/PlowTracer Core/DataStructures/Render/Primitives/Camera/ICamera.cs
+++ b/PlowTracer Core/DataStructures/Render/Primitives/Camera/ICamera.cs
@@ -1,0 +1,33 @@
+﻿using System.Numerics;
+
+using PlowTracer.Core.DataStructures.Render.Primitives.IntersectableEntities;
+
+namespace PlowTracer.Core.DataStructures.Render.Primitives.Camera;
+
+internal interface ICamera
+{
+    Scene   Scene  { get; }
+    
+    Vector3 Origin      { get; }
+    int     Width       { get; }
+    int     Height      { get; }
+    float   AspectRatio { get; }
+    float   FieldOfView { get; }
+    float   FocalLength { get; }
+    
+    float ViewportHeight { get; }
+    float ViewportWidth   { get; }
+    
+    Vector3 ViewportU { get; }
+    Vector3 ViewportV { get; }
+    
+    Vector3 PixelOffsetU { get; }
+    Vector3 PixelOffsetV { get; }
+    
+    Vector3 ViewportOrigin { get; }
+    Vector3 PixelOrigin { get; }
+
+    Ray GetRay(int p_x, int p_y);
+
+    Vector3 GetPixelColor(ref Ray p_ray);
+}

--- a/PlowTracer Core/DataStructures/Render/Primitives/Camera/ThinLensCamera.cs
+++ b/PlowTracer Core/DataStructures/Render/Primitives/Camera/ThinLensCamera.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Numerics;
+
+using PlowTracer.Core.DataStructures.Render.Primitives.IntersectableEntities;
+using PlowTracer.Core.DataStructures.Render.Settings;
+using PlowTracer.Core.DataStructures.Utilities;
+
+namespace PlowTracer.Core.DataStructures.Render.Primitives.Camera;
+
+internal readonly record struct ThinLensCamera : ICamera
+{
+    internal ThinLensCamera(RenderSettings p_renderSettings, Scene p_scene)
+    {
+        Scene = p_scene;
+        
+        Origin = p_renderSettings.CameraOrigin;
+        
+        Width = p_renderSettings.Width;
+        Height = p_renderSettings.Height;
+        
+        AspectRatio = Width / (float)Height;
+        FieldOfView = p_renderSettings.CameraFieldOfView;
+        FocalLength = p_renderSettings.CameraFocalLength;
+        
+        var theta = MathUtilities.DegreesToRadians(FieldOfView);
+        var h     = MathF.Tan(theta / 2);
+
+        ViewportHeight = 2              * h * FocalLength;
+        ViewportWidth  = ViewportHeight * AspectRatio;
+        
+        ViewportU = new Vector3(ViewportWidth, 0, 0);
+        ViewportV = new Vector3(0, -ViewportHeight, 0);
+        
+        PixelOffsetU = ViewportU / Width;
+        PixelOffsetV = ViewportV / Height;
+        
+        ViewportOrigin = Origin - new Vector3(0, 0, FocalLength) - ViewportU / 2 - ViewportV / 2;
+        PixelOrigin = ViewportOrigin + 0.5f * (PixelOffsetU + PixelOffsetV);
+    }
+    
+    public Scene   Scene  { get; }
+    
+    public  Vector3 Origin { get; }
+    
+    public int Width  { get; }
+    public int Height { get; }
+
+    public float AspectRatio { get; }
+    public float FieldOfView { get; }
+    public float FocalLength { get; }
+    
+    public float ViewportHeight { get; }
+    public float ViewportWidth { get; }
+    
+    public Vector3 ViewportU { get; }
+    public Vector3 ViewportV { get; }
+    
+    public Vector3 PixelOffsetU { get; }
+    public Vector3 PixelOffsetV { get; }
+    
+    public Vector3 ViewportOrigin { get; }
+    public Vector3 PixelOrigin { get; }
+    
+    public Ray GetRay(int p_x, int p_y)
+    {
+        var pixelTarget = PixelOrigin + p_x * PixelOffsetU + p_y * PixelOffsetV;
+
+        return new Ray(Origin, pixelTarget - Origin);
+    }
+    
+    public Vector3 GetPixelColor(ref Ray p_ray)
+    {
+        var intersection = Scene.GetIntersection(ref p_ray);
+        
+        if ( intersection.Intersected )
+        {
+            return 0.5f * ( intersection.Normal + Vector3.One );
+        }
+
+        var unitDirection = Vector3.Normalize(p_ray.Direction);
+        var a             = 0.5f * ( unitDirection.Y + 1.0f );
+        return ( 1.0f - a ) * Vector3.One + a * new Vector3(0.5f, 0.7f, 1.0f);
+    }
+}

--- a/PlowTracer Core/DataStructures/Render/Settings/RenderSettings.cs
+++ b/PlowTracer Core/DataStructures/Render/Settings/RenderSettings.cs
@@ -1,13 +1,15 @@
 ﻿using System;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 [assembly:InternalsVisibleTo("PlowTracer.Core.Tests")]
 
 namespace PlowTracer.Core.DataStructures.Render.Settings;
 
-public record RenderSettings
+public readonly record struct RenderSettings
 {
-    public RenderSettings(int p_width, int p_height)
+    public RenderSettings(int p_width, int p_height,
+                          Vector3 p_cameraOrigin, float p_cameraFieldOfView, float p_cameraFocalLength)
     {
         if ( p_width < 2 || p_height < 2 )
         {
@@ -16,8 +18,16 @@ public record RenderSettings
         
         Width = p_width;
         Height = p_height;
+        
+        CameraOrigin = p_cameraOrigin;
+        CameraFieldOfView = p_cameraFieldOfView;
+        CameraFocalLength = p_cameraFocalLength;
     }
     
     internal int Width { get; }
     internal int Height { get; }
+    
+    internal Vector3 CameraOrigin      { get; }
+    internal float   CameraFieldOfView { get; }
+    internal float   CameraFocalLength { get; }
 }

--- a/PlowTracer Core/DataStructures/Utilities/MathUtilities.cs
+++ b/PlowTracer Core/DataStructures/Utilities/MathUtilities.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace PlowTracer.Core.DataStructures.Utilities;
+
+internal static class MathUtilities
+{
+    internal static float DegreesToRadians(float p_degrees)
+    {
+        return MathF.PI / 180 * p_degrees;
+    }
+
+    internal static float RadiansToDegrees(float p_radians)
+    {
+        return 180 / MathF.PI * p_radians;
+    }
+}

--- a/PlowTracer GUI/PlowTracerGuiApplication.axaml
+++ b/PlowTracer GUI/PlowTracerGuiApplication.axaml
@@ -157,6 +157,13 @@
                 <Setter Property="HorizontalAlignment" Value="Left" />
             </Style>
         </Style>
+        
+        <Style Selector="layout|LayoutItem TextBlock">
+            <Setter Property="FontSize" Value="10" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+        </Style>
 
         <Style Selector="Button.standard">
             <Setter Property="HorizontalAlignment" Value="Stretch" />

--- a/PlowTracer GUI/ViewModels/MainWindowViewModel.cs
+++ b/PlowTracer GUI/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
@@ -20,6 +21,8 @@ using PlowTracer.GUI.Models.Enumerations.Logging;
 using PlowTracer.GUI.Models.Extensions.Logging;
 
 using ReactiveUI.Fody.Helpers;
+
+using Vector = Avalonia.Vector;
 
 namespace PlowTracer.GUI.ViewModels;
 
@@ -53,12 +56,20 @@ internal class MainWindowViewModel : ViewModelBase
     public AvaloniaList<IRenderKernel> RenderKernels { get; } = [new ColorOutputTestKernel(),
                                                                     new RayTestKernel(),
                                                                     new SphereTestKernel(),
-                                                                    new SurfaceNormalTestKernel()];
+                                                                    new SurfaceNormalTestKernel(),
+                                                                    new CameraTestKernel()];
 
     [Reactive] public IRenderKernel SelectedRenderKernel { get; set; }
     
     [Reactive] public int RenderWidth  { get; set; } = 1366;
     [Reactive] public int RenderHeight { get; set; } = 768;
+    
+    [Reactive] public float CameraXPosition   { get; set; } = 0.0f;
+    [Reactive] public float CameraYPosition   { get; set; } = 0.0f;
+    [Reactive] public float CameraZPosition   { get; set; } = 0.0f;
+    
+    [Reactive] public float CameraFieldOfView { get; set; } = 90.0f;
+    [Reactive] public float CameraFocalLength { get; set; } = 1.0f;
     
     [Reactive] public required Bitmap OutputImage       { get; set; }
     
@@ -88,7 +99,7 @@ internal class MainWindowViewModel : ViewModelBase
         {
             RenderIsRunning = true;
             
-            using var result = await SelectedRenderKernel.Render(new RenderSettings(RenderWidth, RenderHeight));
+            using var result = await SelectedRenderKernel.Render(new RenderSettings(RenderWidth, RenderHeight, new Vector3(CameraXPosition, CameraYPosition, CameraZPosition), CameraFieldOfView, CameraFocalLength));
             
             stopwatch.Stop();
         

--- a/PlowTracer GUI/Views/RenderSettingsView.axaml
+++ b/PlowTracer GUI/Views/RenderSettingsView.axaml
@@ -37,6 +37,48 @@
                     </layout:LayoutItem>
                 </layout:LayoutGroup>
             </layout:CardContainer>
+            <layout:CardContainer>
+                <layout:CardContainer.HeaderContent>
+                    <layout:CardTitleHeader IconKind="CameraPartyMode"
+                                            Title="Camera" />
+                </layout:CardContainer.HeaderContent>
+                <StackPanel Orientation="Vertical"
+                            Spacing="4">
+                    <layout:CardContainer ShowShadow="False"
+                                          BorderThickness="1">
+                        <layout:CardContainer.HeaderContent>
+                            <layout:CardTitleHeader IconKind="AxisArrow"
+                                                    Title="Origin" />
+                        </layout:CardContainer.HeaderContent>
+                        <layout:LayoutGroup ItemsSpacing="4">
+                            <layout:LayoutItem Label="X:">
+                                <NumericUpDown Value="{Binding CameraXPosition}" />
+                            </layout:LayoutItem>
+                            <layout:LayoutItem Label="Y:">
+                                <NumericUpDown Value="{Binding CameraYPosition}" />
+                            </layout:LayoutItem>
+                            <layout:LayoutItem Label="Z:">
+                                <NumericUpDown Value="{Binding CameraZPosition}" />
+                            </layout:LayoutItem>
+                        </layout:LayoutGroup>
+                    </layout:CardContainer>
+                    <layout:CardContainer ShowShadow="False"
+                                          BorderThickness="1">
+                        <layout:CardContainer.HeaderContent>
+                            <layout:CardTitleHeader IconKind="FocusField"
+                                                    Title="Optics" />
+                        </layout:CardContainer.HeaderContent>
+                        <layout:LayoutGroup ItemsSpacing="4">
+                            <layout:LayoutItem Label="Focal Length:">
+                                <NumericUpDown Value="{Binding CameraFocalLength}" />
+                            </layout:LayoutItem>
+                            <layout:LayoutItem Label="Field of View:">
+                                <NumericUpDown Value="{Binding CameraFieldOfView}" />
+                            </layout:LayoutItem>
+                        </layout:LayoutGroup>
+                    </layout:CardContainer>
+                </StackPanel>
+            </layout:CardContainer>
         </StackPanel>
     </ScrollViewer>
 


### PR DESCRIPTION
- Implemented `CameraTestKernel` for rendering a test scene using a camera.
- Added `ICamera` interface to standardize camera operations such as `GetRay` and `GetPixelColor`.
- Developed `ThinLensCamera` class implementing `ICamera`, handling camera parameters and ray generation.
- Introduced `MathUtilities` class for angle conversion methods critical to camera calculations.
- Extended `RenderSettings` structure to include camera properties like origin, field of view, and focal length.
- Updated `RenderSettingsView.axaml` with UI components for user input of camera parameters.
- Modified various kernel test files to incorporate updated `RenderSettings` constructor.
- Enhanced `MainWindowViewModel` to bind camera settings from the UI and pass them to rendering kernels.