### PR TITLE
Implemented Chapter 8 of Ray Tracing In One Weekend

### DIFF
--- a/PlowTracer Core Tests/Core/Kernels/ColorOutputTestKernelTests.cs
+++ b/PlowTracer Core Tests/Core/Kernels/ColorOutputTestKernelTests.cs
@@ -22,7 +22,7 @@ public class ColorOutputTestKernelTests
     [InlineData(256, 256)]
     public void TEST_CreateRenderSettings(int p_width, int p_height)
     {
-        var renderSettings = new RenderSettings(p_width, p_height, Vector3.Zero, 90, 1);
+        var renderSettings = new RenderSettings(p_width, p_height, 1, Vector3.Zero, 90, 1);
         
         renderSettings.Should().NotBeNull();
         renderSettings.Width.Should().Be(p_width);
@@ -34,7 +34,7 @@ public class ColorOutputTestKernelTests
     {
         var createRenderSettingsAction = () =>
                                          {
-                                             _ = new RenderSettings(1, 1, Vector3.Zero, 90, 1);
+                                             _ = new RenderSettings(1, 1, 1, Vector3.Zero, 90, 1);
                                          };
 
         createRenderSettingsAction.Should().Throw<ArgumentException>();
@@ -51,7 +51,7 @@ public class ColorOutputTestKernelTests
     [InlineData(256, 256)]
     public async Task TEST_Render(int p_width, int p_height)
     {
-        var renderSettings = new RenderSettings(p_width, p_height, Vector3.Zero, 90, 1);
+        var renderSettings = new RenderSettings(p_width, p_height, 1, Vector3.Zero, 90, 1);
 
         var kernel = new ColorOutputTestKernel();
 

--- a/PlowTracer Core/Core/Kernels/MultisampleTestKernel.cs
+++ b/PlowTracer Core/Core/Kernels/MultisampleTestKernel.cs
@@ -10,7 +10,7 @@ using PlowTracer.Core.DataStructures.Render.Settings;
 
 namespace PlowTracer.Core.Core.Kernels;
 
-public class CameraTestKernel : IRenderKernel
+public class MultisampleTestKernel : IRenderKernel
 {
     public async Task<RenderResult> Render(RenderSettings p_settings)
     {
@@ -27,12 +27,21 @@ public class CameraTestKernel : IRenderKernel
 
         var resultDataIndex = 0; // Image format is a flat array, so start at 0 index and count up for each inserted value. - Comment by Matt Heimlich on 11/14/2024 @ 16:55:27
 
+        var sampleScale = 1.0f / p_settings.Samples;
+        
         for ( var row = 0; row < p_settings.Height; ++row )
         {
             for ( var column = 0; column < p_settings.Width; ++column )
             {
-                var ray = camera.GetRay(column, row);
-                var pixelColor = camera.GetPixelColor(ref ray);
+                var pixelColor = Vector3.Zero;
+                
+                for ( var sample = 0; sample < p_settings.Samples; ++sample )
+                {
+                    var ray = camera.GetRay(column, row, p_settings.Samples > 1);
+                    pixelColor += camera.GetPixelColor(ref ray);
+                }
+
+                pixelColor *= sampleScale;
 
                 var formattedRed   = (int)MathF.Round(255 * Math.Clamp(pixelColor.X, 0.0f, 0.999f), MidpointRounding.AwayFromZero);
                 var formattedGreen = (int)MathF.Round(255 * Math.Clamp(pixelColor.Y, 0.0f, 0.999f), MidpointRounding.AwayFromZero);
@@ -50,6 +59,6 @@ public class CameraTestKernel : IRenderKernel
 
     public override string ToString()
     {
-        return "Camera Test";
+        return "Multisample Test";
     }
 }

--- a/PlowTracer Core/DataStructures/Render/Primitives/Camera/ICamera.cs
+++ b/PlowTracer Core/DataStructures/Render/Primitives/Camera/ICamera.cs
@@ -9,25 +9,12 @@ internal interface ICamera
     Scene   Scene  { get; }
     
     Vector3 Origin      { get; }
-    int     Width       { get; }
-    int     Height      { get; }
-    float   AspectRatio { get; }
-    float   FieldOfView { get; }
-    float   FocalLength { get; }
-    
-    float ViewportHeight { get; }
-    float ViewportWidth   { get; }
-    
-    Vector3 ViewportU { get; }
-    Vector3 ViewportV { get; }
     
     Vector3 PixelOffsetU { get; }
     Vector3 PixelOffsetV { get; }
-    
-    Vector3 ViewportOrigin { get; }
     Vector3 PixelOrigin { get; }
 
-    Ray GetRay(int p_x, int p_y);
+    Ray GetRay(int p_x, int p_y, bool p_multiSampled);
 
     Vector3 GetPixelColor(ref Ray p_ray);
 }

--- a/PlowTracer Core/DataStructures/Render/Primitives/Camera/ThinLensCamera.cs
+++ b/PlowTracer Core/DataStructures/Render/Primitives/Camera/ThinLensCamera.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 using PlowTracer.Core.DataStructures.Render.Primitives.IntersectableEntities;
 using PlowTracer.Core.DataStructures.Render.Settings;
@@ -15,59 +16,43 @@ internal readonly record struct ThinLensCamera : ICamera
         
         Origin = p_renderSettings.CameraOrigin;
         
-        Width = p_renderSettings.Width;
-        Height = p_renderSettings.Height;
+        var aspectRatio = p_renderSettings.Width / (float)p_renderSettings.Height;
+        var fieldOfView = p_renderSettings.CameraFieldOfView;
+        var focalLength = p_renderSettings.CameraFocalLength;
         
-        AspectRatio = Width / (float)Height;
-        FieldOfView = p_renderSettings.CameraFieldOfView;
-        FocalLength = p_renderSettings.CameraFocalLength;
-        
-        var theta = MathUtilities.DegreesToRadians(FieldOfView);
+        var theta = MathUtilities.DegreesToRadians(fieldOfView);
         var h     = MathF.Tan(theta / 2);
 
-        ViewportHeight = 2              * h * FocalLength;
-        ViewportWidth  = ViewportHeight * AspectRatio;
+        var viewportHeight = 2              * h * focalLength;
+        var viewportWidth  = viewportHeight * aspectRatio;
         
-        ViewportU = new Vector3(ViewportWidth, 0, 0);
-        ViewportV = new Vector3(0, -ViewportHeight, 0);
+        var viewportU = new Vector3(viewportWidth, 0, 0);
+        var viewportV = new Vector3(0, -viewportHeight, 0);
         
-        PixelOffsetU = ViewportU / Width;
-        PixelOffsetV = ViewportV / Height;
+        PixelOffsetU = viewportU / p_renderSettings.Width;
+        PixelOffsetV = viewportV / p_renderSettings.Height;
         
-        ViewportOrigin = Origin - new Vector3(0, 0, FocalLength) - ViewportU / 2 - ViewportV / 2;
-        PixelOrigin = ViewportOrigin + 0.5f * (PixelOffsetU + PixelOffsetV);
+        var viewportOrigin = Origin - new Vector3(0, 0, focalLength) - viewportU / 2 - viewportV / 2;
+        PixelOrigin = viewportOrigin + 0.5f * (PixelOffsetU + PixelOffsetV);
     }
     
     public Scene   Scene  { get; }
-    
-    public  Vector3 Origin { get; }
-    
-    public int Width  { get; }
-    public int Height { get; }
 
-    public float AspectRatio { get; }
-    public float FieldOfView { get; }
-    public float FocalLength { get; }
-    
-    public float ViewportHeight { get; }
-    public float ViewportWidth { get; }
-    
-    public Vector3 ViewportU { get; }
-    public Vector3 ViewportV { get; }
-    
+    public Vector3 Origin       { get; }
     public Vector3 PixelOffsetU { get; }
     public Vector3 PixelOffsetV { get; }
+    public Vector3 PixelOrigin  { get; }
     
-    public Vector3 ViewportOrigin { get; }
-    public Vector3 PixelOrigin { get; }
-    
-    public Ray GetRay(int p_x, int p_y)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Ray GetRay(int p_x, int p_y, bool p_multiSampled = true)
     {
-        var pixelTarget = PixelOrigin + p_x * PixelOffsetU + p_y * PixelOffsetV;
+        var offset      = p_multiSampled ? MathUtilities.GetRandomPointInUnitSquare() : Vector2.Zero;
+        var pixelTarget = PixelOrigin + (p_x + offset.X) * PixelOffsetU + (p_y + offset.Y) * PixelOffsetV;
 
         return new Ray(Origin, pixelTarget - Origin);
     }
     
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Vector3 GetPixelColor(ref Ray p_ray)
     {
         var intersection = Scene.GetIntersection(ref p_ray);

--- a/PlowTracer Core/DataStructures/Render/Settings/RenderSettings.cs
+++ b/PlowTracer Core/DataStructures/Render/Settings/RenderSettings.cs
@@ -8,7 +8,7 @@ namespace PlowTracer.Core.DataStructures.Render.Settings;
 
 public readonly record struct RenderSettings
 {
-    public RenderSettings(int p_width, int p_height,
+    public RenderSettings(int p_width, int p_height, int p_samples,
                           Vector3 p_cameraOrigin, float p_cameraFieldOfView, float p_cameraFocalLength)
     {
         if ( p_width < 2 || p_height < 2 )
@@ -18,14 +18,16 @@ public readonly record struct RenderSettings
         
         Width = p_width;
         Height = p_height;
+        Samples = p_samples;
         
         CameraOrigin = p_cameraOrigin;
         CameraFieldOfView = p_cameraFieldOfView;
         CameraFocalLength = p_cameraFocalLength;
     }
     
-    internal int Width { get; }
-    internal int Height { get; }
+    internal int Width   { get; }
+    internal int Height  { get; }
+    internal int Samples { get; }
     
     internal Vector3 CameraOrigin      { get; }
     internal float   CameraFieldOfView { get; }

--- a/PlowTracer Core/DataStructures/Utilities/MathUtilities.cs
+++ b/PlowTracer Core/DataStructures/Utilities/MathUtilities.cs
@@ -1,16 +1,26 @@
 ﻿using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace PlowTracer.Core.DataStructures.Utilities;
 
 internal static class MathUtilities
 {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static float DegreesToRadians(float p_degrees)
     {
         return MathF.PI / 180 * p_degrees;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static float RadiansToDegrees(float p_radians)
     {
         return 180 / MathF.PI * p_radians;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Vector2 GetRandomPointInUnitSquare()
+    {
+        return new Vector2(Random.Shared.NextSingle() - 0.5f, Random.Shared.NextSingle() - 0.5f);
     }
 }

--- a/PlowTracer GUI/ViewModels/MainWindowViewModel.cs
+++ b/PlowTracer GUI/ViewModels/MainWindowViewModel.cs
@@ -57,16 +57,18 @@ internal class MainWindowViewModel : ViewModelBase
                                                                     new RayTestKernel(),
                                                                     new SphereTestKernel(),
                                                                     new SurfaceNormalTestKernel(),
-                                                                    new CameraTestKernel()];
+                                                                    new CameraTestKernel(),
+                                                                    new MultisampleTestKernel()];
 
     [Reactive] public IRenderKernel SelectedRenderKernel { get; set; }
     
-    [Reactive] public int RenderWidth  { get; set; } = 1366;
-    [Reactive] public int RenderHeight { get; set; } = 768;
+    [Reactive] public int RenderWidth   { get; set; } = 1366;
+    [Reactive] public int RenderHeight  { get; set; } = 768;
+    [Reactive] public int RenderSamples { get; set; } = 1;
     
-    [Reactive] public float CameraXPosition   { get; set; } = 0.0f;
-    [Reactive] public float CameraYPosition   { get; set; } = 0.0f;
-    [Reactive] public float CameraZPosition   { get; set; } = 0.0f;
+    [Reactive] public float CameraXPosition   { get; set; }
+    [Reactive] public float CameraYPosition   { get; set; }
+    [Reactive] public float CameraZPosition   { get; set; }
     
     [Reactive] public float CameraFieldOfView { get; set; } = 90.0f;
     [Reactive] public float CameraFocalLength { get; set; } = 1.0f;
@@ -99,7 +101,7 @@ internal class MainWindowViewModel : ViewModelBase
         {
             RenderIsRunning = true;
             
-            using var result = await SelectedRenderKernel.Render(new RenderSettings(RenderWidth, RenderHeight, new Vector3(CameraXPosition, CameraYPosition, CameraZPosition), CameraFieldOfView, CameraFocalLength));
+            using var result = await SelectedRenderKernel.Render(new RenderSettings(RenderWidth, RenderHeight, RenderSamples, new Vector3(CameraXPosition, CameraYPosition, CameraZPosition), CameraFieldOfView, CameraFocalLength));
             
             stopwatch.Stop();
         

--- a/PlowTracer GUI/Views/RenderSettingsView.axaml
+++ b/PlowTracer GUI/Views/RenderSettingsView.axaml
@@ -35,6 +35,9 @@
                     <layout:LayoutItem Label="Height:">
                         <NumericUpDown Value="{Binding RenderHeight}" />
                     </layout:LayoutItem>
+                    <layout:LayoutItem Label="Samples:">
+                        <NumericUpDown Value="{Binding RenderSamples}" />
+                    </layout:LayoutItem>
                 </layout:LayoutGroup>
             </layout:CardContainer>
             <layout:CardContainer>


### PR DESCRIPTION
- Introduced `MultisampleTestKernel` class for enhanced rendering with multiple samples per pixel.
- Updated `RenderSettings` to include a `Samples` property for configurable sampling rates.
- Enhanced `ThinLensCamera` to support multisampling via jittered rays for anti-aliasing.
- Modified `RenderSettingsView`, `MainWindowViewModel`, and related files to incorporate sampling settings in the GUI.
- Added clamping to pixel color calculations in `CameraTestKernel` to prevent overflow and ensure color accuracy.
- Expanded `MathUtilities` with a method for generating random points, aiding in multisampling.
- Refactored code to streamline dependencies and maintain consistency across the project.