### PR TITLE
Implemented Chapter 12 of Ray Tracing In One Weekend 

### DIFF
--- a/PlowTracer Core Tests/Core/Kernels/ColorOutputTestKernelTests.cs
+++ b/PlowTracer Core Tests/Core/Kernels/ColorOutputTestKernelTests.cs
@@ -22,7 +22,7 @@ public class ColorOutputTestKernelTests
     [InlineData(256, 256)]
     public void TEST_CreateRenderSettings(int p_width, int p_height)
     {
-        var renderSettings = new RenderSettings(p_width, p_height, 1, 1, Vector3.Zero, 90, 1);
+        var renderSettings = new RenderSettings(p_width, p_height, 1, 1, Vector3.Zero, Vector3.Zero, Vector3.Zero, 90, 1);
         
         renderSettings.Should().NotBeNull();
         renderSettings.Width.Should().Be(p_width);
@@ -34,7 +34,7 @@ public class ColorOutputTestKernelTests
     {
         var createRenderSettingsAction = () =>
                                          {
-                                             _ = new RenderSettings(1, 1, 1, 1, Vector3.Zero, 90, 1);
+                                             _ = new RenderSettings(1, 1, 1, 1, Vector3.Zero, Vector3.Zero, Vector3.Zero, 90, 1);
                                          };
 
         createRenderSettingsAction.Should().Throw<ArgumentException>();
@@ -51,7 +51,7 @@ public class ColorOutputTestKernelTests
     [InlineData(256, 256)]
     public async Task TEST_Render(int p_width, int p_height)
     {
-        var renderSettings = new RenderSettings(p_width, p_height, 1, 1, Vector3.Zero, 90, 1);
+        var renderSettings = new RenderSettings(p_width, p_height, 1, 1, Vector3.Zero, Vector3.Zero, Vector3.Zero, 90, 1);
 
         var kernel = new ColorOutputTestKernel();
 

--- a/PlowTracer Core/DataStructures/Render/Primitives/Camera/ThinLensCamera.cs
+++ b/PlowTracer Core/DataStructures/Render/Primitives/Camera/ThinLensCamera.cs
@@ -16,6 +16,7 @@ internal readonly record struct ThinLensCamera : ICamera
         Scene = p_scene;
         
         Origin = p_renderSettings.CameraOrigin;
+        Target = p_renderSettings.CameraTarget;
         
         var aspectRatio = p_renderSettings.Width / (float)p_renderSettings.Height;
         var fieldOfView = p_renderSettings.CameraFieldOfView;
@@ -27,19 +28,29 @@ internal readonly record struct ThinLensCamera : ICamera
         var viewportHeight = 2              * h * focalLength;
         var viewportWidth  = viewportHeight * aspectRatio;
         
-        var viewportU = new Vector3(viewportWidth, 0, 0);
-        var viewportV = new Vector3(0, -viewportHeight, 0);
+        var w = Vector3.Normalize(Origin - Target);
+        var u = Vector3.Normalize(Vector3.Cross(p_renderSettings.CameraUp, w));
+        var v = Vector3.Cross(w, u);
+
+        var viewportU = viewportWidth * u;
+        var viewportV = viewportHeight * -v;
         
         PixelOffsetU = viewportU / p_renderSettings.Width;
         PixelOffsetV = viewportV / p_renderSettings.Height;
         
-        var viewportOrigin = Origin - new Vector3(0, 0, focalLength) - viewportU / 2 - viewportV / 2;
+        var viewportOrigin = Origin - focalLength * w - viewportU / 2 - viewportV / 2;
         PixelOrigin = viewportOrigin + 0.5f * (PixelOffsetU + PixelOffsetV);
     }
     
     public Scene   Scene  { get; }
 
     public Vector3 Origin       { get; }
+    public Vector3 Target       { get; }
+    
+    // private Vector3 U { get; }
+    // private Vector3 V { get; }
+    // public  Vector3 W { get; }
+    
     public Vector3 PixelOffsetU { get; }
     public Vector3 PixelOffsetV { get; }
     public Vector3 PixelOrigin  { get; }

--- a/PlowTracer Core/DataStructures/Render/Settings/RenderSettings.cs
+++ b/PlowTracer Core/DataStructures/Render/Settings/RenderSettings.cs
@@ -2,14 +2,21 @@
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
-[assembly:InternalsVisibleTo("PlowTracer.Core.Tests")]
+[assembly: InternalsVisibleTo("PlowTracer.Core.Tests")]
 
 namespace PlowTracer.Core.DataStructures.Render.Settings;
 
 public readonly record struct RenderSettings
 {
-    public RenderSettings(int p_width, int p_height, int p_samples, int p_maxBounces,
-                          Vector3 p_cameraOrigin, float p_cameraFieldOfView, float p_cameraFocalLength)
+    public RenderSettings(int     p_width,
+                          int     p_height,
+                          int     p_samples,
+                          int     p_maxBounces,
+                          Vector3 p_cameraOrigin,
+                          Vector3 p_cameraTarget,
+                          Vector3 p_cameraUp,
+                          float   p_cameraFieldOfView,
+                          float   p_cameraFocalLength)
     {
         if ( p_width < 2 || p_height < 2 )
         {
@@ -20,23 +27,27 @@ public readonly record struct RenderSettings
         {
             throw new ArgumentException("Max bounces must be at least 1");
         }
-        
+
         Width      = p_width;
         Height     = p_height;
         Samples    = p_samples;
         MaxBounces = p_maxBounces;
-        
+
         CameraOrigin      = p_cameraOrigin;
+        CameraTarget      = p_cameraTarget;
+        CameraUp          = p_cameraUp;
         CameraFieldOfView = p_cameraFieldOfView;
         CameraFocalLength = p_cameraFocalLength;
     }
-    
+
     internal int Width      { get; }
     internal int Height     { get; }
     internal int Samples    { get; }
     internal int MaxBounces { get; }
-    
+
     internal Vector3 CameraOrigin      { get; }
+    internal Vector3 CameraTarget      { get; }
+    internal Vector3 CameraUp          { get; }
     internal float   CameraFieldOfView { get; }
     internal float   CameraFocalLength { get; }
 }

--- a/PlowTracer GUI/ViewModels/MainWindowViewModel.cs
+++ b/PlowTracer GUI/ViewModels/MainWindowViewModel.cs
@@ -71,11 +71,19 @@ internal class MainWindowViewModel : ViewModelBase
     
     [Reactive] public int RenderSamples { get; set; } = 1;
 
-    [Reactive] public int MaxLightBounces { get; set; } = 10;
+    [Reactive] public int MaxLightBounces { get; set; } = 15;
     
     [Reactive] public float CameraXPosition   { get; set; }
     [Reactive] public float CameraYPosition   { get; set; }
     [Reactive] public float CameraZPosition   { get; set; }
+    
+    [Reactive] public float CameraTargetXPosition { get; set; }
+    [Reactive] public float CameraTargetYPosition { get; set; }
+    [Reactive] public float CameraTargetZPosition { get; set; } = -1.0f;
+    
+    [Reactive] public float CameraUpX { get; set; }
+    [Reactive] public float CameraUpY { get; set; } = 1.0f;
+    [Reactive] public float CameraUpZ { get; set; }
     
     [Reactive] public float CameraFieldOfView { get; set; } = 90.0f;
     [Reactive] public float CameraFocalLength { get; set; } = 1.0f;
@@ -108,7 +116,7 @@ internal class MainWindowViewModel : ViewModelBase
         {
             RenderIsRunning = true;
             
-            using var result = await SelectedRenderKernel.Render(new RenderSettings(RenderWidth, RenderHeight, RenderSamples, MaxLightBounces, new Vector3(CameraXPosition, CameraYPosition, CameraZPosition), CameraFieldOfView, CameraFocalLength));
+            using var result = await SelectedRenderKernel.Render(new RenderSettings(RenderWidth, RenderHeight, RenderSamples, MaxLightBounces, new Vector3(CameraXPosition, CameraYPosition, CameraZPosition), new Vector3(CameraTargetXPosition, CameraTargetYPosition, CameraTargetZPosition), new Vector3(CameraUpX, CameraUpY, CameraUpZ), CameraFieldOfView, CameraFocalLength));
             
             stopwatch.Stop();
         

--- a/PlowTracer GUI/Views/RenderSettingsView.axaml
+++ b/PlowTracer GUI/Views/RenderSettingsView.axaml
@@ -87,6 +87,42 @@
                     <layout:CardContainer ShowShadow="False"
                                           BorderThickness="1">
                         <layout:CardContainer.HeaderContent>
+                            <layout:CardTitleHeader IconKind="AxisArrow"
+                                                    Title="Target" />
+                        </layout:CardContainer.HeaderContent>
+                        <layout:LayoutGroup ItemsSpacing="4">
+                            <layout:LayoutItem Label="X:">
+                                <NumericUpDown Value="{Binding CameraTargetXPosition}" />
+                            </layout:LayoutItem>
+                            <layout:LayoutItem Label="Y:">
+                                <NumericUpDown Value="{Binding CameraTargetYPosition}" />
+                            </layout:LayoutItem>
+                            <layout:LayoutItem Label="Z:">
+                                <NumericUpDown Value="{Binding CameraTargetZPosition}" />
+                            </layout:LayoutItem>
+                        </layout:LayoutGroup>
+                    </layout:CardContainer>
+                    <layout:CardContainer ShowShadow="False"
+                                          BorderThickness="1">
+                        <layout:CardContainer.HeaderContent>
+                            <layout:CardTitleHeader IconKind="AxisArrow"
+                                                    Title="Up Vector" />
+                        </layout:CardContainer.HeaderContent>
+                        <layout:LayoutGroup ItemsSpacing="4">
+                            <layout:LayoutItem Label="X:">
+                                <NumericUpDown Value="{Binding CameraUpX}" />
+                            </layout:LayoutItem>
+                            <layout:LayoutItem Label="Y:">
+                                <NumericUpDown Value="{Binding CameraUpY}" />
+                            </layout:LayoutItem>
+                            <layout:LayoutItem Label="Z:">
+                                <NumericUpDown Value="{Binding CameraUpZ}" />
+                            </layout:LayoutItem>
+                        </layout:LayoutGroup>
+                    </layout:CardContainer>
+                    <layout:CardContainer ShowShadow="False"
+                                          BorderThickness="1">
+                        <layout:CardContainer.HeaderContent>
                             <layout:CardTitleHeader IconKind="FocusField"
                                                     Title="Optics" />
                         </layout:CardContainer.HeaderContent>


### PR DESCRIPTION
- Update `RenderSettings` to include camera target and up vector parameters.
  - Added new fields `CameraTarget` and `CameraUp` to `RenderSettings` class.
  - Modified constructor to accept these new parameters and updated internal properties.
- Modify camera setup in `ThinLensCamera` to use target and up vectors.
  - Calculated orthonormal basis vectors using target and up vectors.
  - Updated viewport calculations and pixel offset logic accordingly.
- Update `MainWindowViewModel` and GUI to bind new camera parameters.
  - Added new reactive properties in `MainWindowViewModel` for camera target and up vectors.
  - Modified XAML view to include input fields for these new properties.
- Adjust tests to account for the updated `RenderSettings` constructor.
  - Updated test cases in `ColorOutputTestKernelTests` to use the new constructor with additional parameters.